### PR TITLE
#106 Исправляет неверное значение типа `houses` до `house` в сужении области поиска адреса

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,7 @@ export interface DaDataAddress {
   divisions?: unknown;
 }
 
-export type DaDataAddressBounds = 'country' | 'region' | 'area' | 'city' | 'settlement' | 'street' | 'houses';
+export type DaDataAddressBounds = 'country' | 'region' | 'area' | 'city' | 'settlement' | 'street' | 'house';
 
 export type DaDataPartyType = 'LEGAL' | 'INDIVIDUAL';
 


### PR DESCRIPTION
Closes #106 